### PR TITLE
Sample with TOC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 [submodule "themes/ananke"]
 	path = themes/ananke
 	url = git@github.com:budparr/gohugo-theme-ananke.git
+[submodule "themes/zdoc"]
+	path = themes/zdoc
+	url = https://github.com/zzossig/hugo-theme-zdoc.git

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@ contentDir = "docs"
 languageCode = "en-us"
 DefaultContentLanguage = "en"
 title = "Hugo Asciidoc Test"
-theme = "ananke"
+theme = "zdoc"
 
 hasCJKLanguage = true
 metaDataFormat = "yaml"
@@ -17,9 +17,15 @@ enableMissingTranslationPlaceholders = false
 
 [markup.asciidocext]
     extensions = ["asciidoctor-html5s", "asciidoctor-diagram"]
-    backend = "html5s"
+#    backend = "html5s"
     workingFolderCurrent = true
     trace = true
+
+[markup]
+    [markup.tableOfContent]
+        endLevel = 3
+        ordered = false
+        startLevel = 2
 
 #[module]
 #[[module.imports]]
@@ -42,6 +48,9 @@ enableMissingTranslationPlaceholders = false
     # path name excluded from documentation menu
     menu_exclusion = ["archives", "entry", "post", "posts"]
 
+    themeOptions = ["light", "dark"]
+    enableNavbar = true
+    enableToc = true
 
 # Global menu section
 [[menu.main]]


### PR DESCRIPTION
Shows how the TOC is extracted from the document and put in the `.TableOfContents`.

I've just noticed that:
- it does work with standard :toc:, no need to use the macro actually
- it doesn't work with html5s